### PR TITLE
Dockerfiles

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,19 @@
+## docker-compose.yml
+
+# service: db
+DB_HOST=db:3306
+DB_DATABASE=cradlephp_kitchen_sink
+DB_USER=cradlephp
+DB_PASSWORD=cradlephp
+DB_ROOT_PASSWORD=cradlephp
+
+# service: web
+WEB_PORT=8001
+
+## docker-compose.override.yml
+
+# service: web
+WEB_SOURCE_DIR=.
+
+# service: composer
+COMPOSER_HOME_DIR=~/.composer

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,26 @@ app/www/tests/_envs/*
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock
+
+#Editor Files
+/nbproject/private/
+ace
+_ace
+*.doc
+*.docx
+.idea
+.DS_Store
+*.sublime-project
+*.sublime-workspace
+
+# Ignore Composer Directory
+vendor/
+
+# Docker files
+.env
+
+# Ignore Node Modules
+node_modules/
+
+# Vagrant dir
+.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM php:7.1-apache
+MAINTAINER Andre Marcelo-Tanner <andre@enthropia.com>
+
+# Install specific packages
+RUN apt-get update \
+	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    	apache2 \
+    	mysql-client \
+    	vim-tiny \
+    	ca-certificates \
+    	git-core \
+    	ssh \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    docker-php-ext-install mysqli pdo pdo_mysql opcache
+
+# set recommended PHP.ini settings
+# see https://secure.php.net/manual/en/opcache.installation.php
+RUN { \
+		echo 'opcache.memory_consumption=128'; \
+		echo 'opcache.interned_strings_buffer=8'; \
+		echo 'opcache.max_accelerated_files=4000'; \
+		echo 'opcache.revalidate_freq=2'; \
+		echo 'opcache.fast_shutdown=1'; \
+		echo 'opcache.enable_cli=1'; \
+	} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# Fixes empty home
+ENV HOME /root
+
+# add custom ssh config / keys to the root user
+ADD ./opt/docker/ssh/ /root/.ssh/
+
+# add code into web dir
+ADD . /var/www/html
+
+# Change into the directory
+WORKDIR /var/www/html
+
+# Configure
+
+# Adding apache virtual hosts file
+RUN cp ./opt/docker/apache-config/sites-available/000-default.conf /etc/apache2/sites-available/000-default.conf
+
+# enable mods
+RUN a2enmod rewrite expires
+
+# Expose Port 80
+EXPOSE 80
+
+# Volume
+VOLUME /var/www/html
+
+# Run example docker run -it -p 8000:80 -e PHP_TIMEZONE='Asia/Manila' -v .:/var/www/html --name container-name

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:
+  web:
+    volumes:
+      - "${WEB_SOURCE_DIR}:/var/www/html"
+
+  composer:
+    volumes:
+      - "${COMPOSER_HOME_DIR}:/composer"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '2'
+
+services:
+  db:
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD}"
+      MYSQL_DATABASE: "${DB_DATABASE}"
+      MYSQL_USER: "${DB_USER}"
+      MYSQL_PASSWORD: "${DB_PASSWORD}"
+
+  web:
+    build: .
+    image: cryptocharts/cryptocharts:latest
+    depends_on:
+      - db
+    ports:
+      - "${WEB_PORT}:80"
+    volumes:
+      - web_data:/var/www/html
+    restart: always
+    environment:
+      DB_HOST: "${DB_HOST}"
+      DB_USER: "${DB_USER}"
+      DB_PASSWORD: "${DB_PASSWORD}"
+
+  composer:
+    image: kzap/composer:latest
+    depends_on:
+      - web
+    volumes_from:
+      - web
+    working_dir: /var/www/html
+
+  bower:
+    image: kzap/bower:latest
+    depends_on:
+      - web
+    volumes_from:
+      - web
+    working_dir: /var/www/html
+
+volumes:
+  db_data:
+  web_data:

--- a/opt/docker/README.md
+++ b/opt/docker/README.md
@@ -1,0 +1,53 @@
+To use Docker with this app:
+
+#Easy Way
+
+- Copy `.env.sample` as `.env` in your base directory
+
+`$ cp .env.sample .env`
+
+- Edit `.env` with your Custom Settings if needed
+
+`$ vi .env`
+
+	Sample File:
+	```
+	## docker-compose.yml
+
+	# service: db
+	DB_HOST=db:3306
+	DB_DATABASE=cradlephp_kitchen_sink
+	DB_USER=cradlephp
+	DB_PASSWORD=cradlephp
+	DB_ROOT_PASSWORD=cradlephp
+
+	# service: web
+	WEB_PORT=8001
+
+	## docker-compose.override.yml
+
+	# service: web
+	WEB_SOURCE_DIR=.
+
+	# service: composer
+	COMPOSER_HOME_DIR=~/.composer
+	```
+
+- Run `docker-compose up` from your main directory to start the docker instance
+
+`$ docker-compose up`
+
+- Your docker containers will now be running at `http://${DOCKER_IP}:${WEB_PORT}`, your `${DOCKER_IP}` depends on what machine is running your local docker instance but it usually is `0.0.0.0`
+
+- If this is the first time proceed to the `Setting Up` section
+
+#Setting Up
+
+Once the servers are online, the remaining large data needs to be imported into the DB Server
+
+- Connect into your DB container
+  * `docker-compose exec db bash`
+
+- Download and unzip the MySQL Data:
+
+- Import the MySQL Data

--- a/opt/docker/apache-config/sites-available/000-default.conf
+++ b/opt/docker/apache-config/sites-available/000-default.conf
@@ -1,0 +1,31 @@
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	#ServerName www.example.com
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html/public
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog error.log
+	CustomLog access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Can setup `kitchen-sink` by using running `docker-compose up`

See opt/docker/README.md

- Add docker specific configuration files to /opt/docker
- added some ignores to .gitignore
- .env.sample with default variables
- docker-compose.override.yml is development environment settings, not for use in production
- Composer image bzip2 support in Alpine PHP7.1 using kzap/composer image